### PR TITLE
fix: 댓글 수정, 삭제에 verifyCardId 추가

### DIFF
--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -47,9 +47,15 @@ export class CommentsController {
     async updateComment(
         @Request() req,
         @Param('id') id: number,
-        @Body() updatedComment: CommentsModel,
+        @Param('cardId') cardId: number,
+        @Body()
+        updatedComment: CommentsModel,
     ) {
-        const comment = await this.commentsService.updateComment(id, updatedComment);
+        console.log({ cardId });
+        console.log({ id });
+        console.log('===============================================================');
+        console.log(req);
+        const comment = await this.commentsService.updateComment(id, cardId, updatedComment);
         if (comment.userId !== req.userId) {
             throw new ForbiddenException('권한이 없습니다.');
         }
@@ -63,13 +69,13 @@ export class CommentsController {
 
     @UseGuards(AccessTokenGuard)
     @Delete(':cardId/:id')
-    async deleteComment(@Request() req, @Param('id') id: number) {
+    async deleteComment(@Request() req, @Param('id') id: number, @Param('cardId') cardId: number) {
         const comment = await this.commentsService.getCommentById(id);
         if ((comment as CommentsModel)?.userId !== req.userId) {
             throw new ForbiddenException('권한이 없습니다.');
         }
 
-        await this.commentsService.deleteComment(id);
+        await this.commentsService.deleteComment(id, cardId);
         return {
             statusCode: HttpStatus.OK,
             message: '댓글이 삭제되었습니다.',

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -51,10 +51,6 @@ export class CommentsController {
         @Body()
         updatedComment: CommentsModel,
     ) {
-        console.log({ cardId });
-        console.log({ id });
-        console.log('===============================================================');
-        console.log(req);
         const comment = await this.commentsService.updateComment(id, cardId, updatedComment);
         if (comment.userId !== req.userId) {
             throw new ForbiddenException('권한이 없습니다.');

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -46,14 +46,28 @@ export class CommentsService {
         return foundComment;
     }
 
-    async updateComment(id: number, updatedComment: CommentsModel) {
+    async updateComment(id: number, cardId: number, updatedComment: CommentsModel) {
         await this.verifyCommentId(id);
+        await this.verifyCardId(cardId);
+
+        const comment = await this.commentRepository.findOne({ where: { id, cardId } });
+        if (!comment) {
+            throw new NotFoundException('댓글을 찾을 수 없습니다.');
+        }
+
         await this.commentRepository.update(id, updatedComment);
         return this.verifyCommentId(id);
     }
 
-    async deleteComment(id: number) {
+    async deleteComment(id: number, cardId: number) {
         await this.verifyCommentId(id);
+        await this.verifyCardId(cardId);
+
+        const comment = await this.commentRepository.findOne({ where: { id, cardId } });
+        if (!comment) {
+            throw new NotFoundException('댓글을 찾을 수 없습니다.');
+        }
+
         const result = await this.commentRepository.delete(id);
     }
 }


### PR DESCRIPTION
수경님이 card id가 달라도 comment id만 맞으면 수정/삭제 진행되는 부분을 확인해주셨습니다.

verifyCardId를 수정/삭제에도 추가했습니다. 
card id와 comment id (url상 id) 모두 일치해야 수정/삭제 가능하게 수정했습니다.
